### PR TITLE
Improvement: Define recursive function findBasePath explicitly 

### DIFF
--- a/src/evaluate/evaluate-expr/find-basepath.js
+++ b/src/evaluate/evaluate-expr/find-basepath.js
@@ -1,6 +1,6 @@
-const _findBasePath = (scope) => {
-  if (scope.upperScope) return _findBasePath(scope.upperScope);
+const findBasepath = (scope) => {
+  if (scope.upperScope) return findBasepath(scope.upperScope);
   return scope.basepath;
 }
 
-module.exports = _findBasePath;
+module.exports = findBasePath;

--- a/src/evaluate/evaluate-expr/find-basepath.js
+++ b/src/evaluate/evaluate-expr/find-basepath.js
@@ -1,4 +1,6 @@
-module.exports = (scope) => {
-  if (scope.upperScope) return findBasepath(scope.upperScope);
+const _findBasePath = (scope) => {
+  if (scope.upperScope) return _findBasePath(scope.upperScope);
   return scope.basepath;
-};
+}
+
+module.exports = _findBasePath;


### PR DESCRIPTION
It doesn’t look like findBasePath is defined. But it works even though I sometimes get a runtime error for that. Yet, I defined the function explicitly.